### PR TITLE
Minor Wall of Flipper Update

### DIFF
--- a/Evil-Cardputer-v1-3-3.ino
+++ b/Evil-Cardputer-v1-3-3.ino
@@ -7716,7 +7716,7 @@ class MyAdvertisedDeviceCallbacks: public BLEAdvertisedDeviceCallbacks {
       // Continuer uniquement si un Flipper est identifié
       if (isFlipper) {
         String macAddress = advertisedDevice.getAddress().toString().c_str();
-        if (macAddress.startsWith("80:e1:26") || macAddress.startsWith("80:e1:27")) {
+        if (macAddress.startsWith("80:e1:26") || macAddress.startsWith("80:e1:27") || macAddress.startsWith("0C:FA:22")) {
           isValidMac = true;
         }
 

--- a/Evil-M5Core2-1-2-2.ino
+++ b/Evil-M5Core2-1-2-2.ino
@@ -4895,7 +4895,7 @@ class MyAdvertisedDeviceCallbacks: public BLEAdvertisedDeviceCallbacks {
       // Continuer uniquement si un Flipper est identifié
       if (isFlipper) {
         String macAddress = advertisedDevice.getAddress().toString().c_str();
-        if (macAddress.startsWith("80:e1:26") || macAddress.startsWith("80:e1:27")) {
+        if (macAddress.startsWith("80:e1:26") || macAddress.startsWith("80:e1:27") || macAddress.startsWith("0C:FA:22")) {
           isValidMac = true;
         }
 

--- a/Evil-M5Core3-1-1-9.ino
+++ b/Evil-M5Core3-1-1-9.ino
@@ -4833,7 +4833,7 @@ class MyAdvertisedDeviceCallbacks: public BLEAdvertisedDeviceCallbacks {
       // Continuer uniquement si un Flipper est identifié
       if (isFlipper) {
         String macAddress = advertisedDevice.getAddress().toString().c_str();
-        if (macAddress.startsWith("80:e1:26") || macAddress.startsWith("80:e1:27")) {
+        if (macAddress.startsWith("80:e1:26") || macAddress.startsWith("80:e1:27") || macAddress.startsWith("0C:FA:22")) {
           isValidMac = true;
         }
 


### PR DESCRIPTION
Adds new Flipper Devices MAC address prefix to check if detected flippers are valid.

All new produced Flipper will feature as MAC address starting with `0C:FA:22`, as stated by Flipper Devices [here](https://x.com/flipper_zero/status/1839389596200886404) .

Applied update to all relevant devices (those with wall of flipper functionality), not much to test here so I'm making an exception for not making changes to the core2 and core3 as I'm not capable of testing on them.