### PR TITLE
Skimmer Detector Bugfix

### DIFF
--- a/Evil-Cardputer-v1-3-3.ino
+++ b/Evil-Cardputer-v1-3-3.ino
@@ -9379,6 +9379,8 @@ public:
     M5.Display.setTextColor(isSkimmerDetected ? TFT_RED : menuTextFocusedColor);
     M5.Display.setCursor(0, 20);
     M5.Display.println(displayMessage);
+    // Small delay to prevent crashing
+    delay(250);
   }
 };
 


### PR DESCRIPTION
Another very small PR, added a small delay to prevent crashing in areas with many devices.

Without, in areas with a large amount of devices, the skimmer draws each devices to the screen continuously, as fast as it can until the cardputer crashes.