### PR TITLE
Move from SPIFFS to LittleFS

### DIFF
--- a/Evil-Cardputer-v1-5-2.ino
+++ b/Evil-Cardputer-v1-5-2.ino
@@ -24908,7 +24908,7 @@ void scanCCTVCamerasFromFile() {
 
 
 #include <M5GFX.h>
-#include <SPIFFS.h>
+#include <LittleFS.h>
 #include <stdarg.h>
 
 // chemin du fichier liste
@@ -24935,8 +24935,8 @@ static const size_t   IO_CHUNK = 3840;
 static const char* SD_TMP_DIR      = "/evil/tmp";
 static const char* SD_FILE_A       = "/evil/tmp/mjpeg_a.jpg";
 static const char* SD_FILE_B       = "/evil/tmp/mjpeg_b.jpg";
-static const char* SPIFFS_FILE_A   = "/a.jpg";
-static const char* SPIFFS_FILE_B   = "/b.jpg";
+static const char* LittleFS_FILE_A   = "/a.jpg";
+static const char* LittleFS_FILE_B   = "/b.jpg";
 
 // écran Cardputer
 static const int SCREEN_W = 240;
@@ -25748,11 +25748,11 @@ void runCCTV_MJPEGViewer() {
   enterDebounce();
   M5.Display.setTextSize(1);
 
-  bool spiffs_ok = false;
+  bool LittleFS_ok = false;
   bool sd_ok = true;
-  if (!sd_ok) spiffs_ok = SPIFFS.begin(true);
-  if (!sd_ok && !spiffs_ok) {
-    uiText(2, 2, "No SD/SPIFFS. Aborting.", TFT_RED);
+  if (!sd_ok) LittleFS_ok = LittleFS.begin(true);
+  if (!sd_ok && !LittleFS_ok) {
+    uiText(2, 2, "No SD/LittleFS. Aborting.", TFT_RED);
     while (1) delay(1000);
   }
   if (sd_ok && !SD.exists(SD_TMP_DIR)) SD.mkdir(SD_TMP_DIR);
@@ -25762,9 +25762,9 @@ void runCCTV_MJPEGViewer() {
     loadFallbackStreams();
   }
 
-  fs::FS* pfs = sd_ok ? (fs::FS*)&SD : (fs::FS*)&SPIFFS;
-  const char* fileA = sd_ok ? SD_FILE_A : SPIFFS_FILE_A;
-  const char* fileB = sd_ok ? SD_FILE_B : SPIFFS_FILE_B;
+  fs::FS* pfs = sd_ok ? (fs::FS*)&SD : (fs::FS*)&LittleFS;
+  const char* fileA = sd_ok ? SD_FILE_A : LittleFS_FILE_A;
+  const char* fileB = sd_ok ? SD_FILE_B : LittleFS_FILE_B;
 
   // Boucle globale : on reste ici tant que l'utilisateur ne remonte pas au menu parent
   while (!kp('`')) {

--- a/Evil-Face-Dial-v1-0.ino
+++ b/Evil-Face-Dial-v1-0.ino
@@ -28,7 +28,7 @@
    Users are required to comply with all applicable laws and regulations in their jurisdiction 
    regarding network testing and ethical hacking.
 */
-#include <SPIFFS.h>
+#include <LittleFS.h>
 #include <M5Unified.h>
 #include <Avatar.h>
 #include <Wire.h>
@@ -107,14 +107,14 @@ void setup() {
     auto cfg = M5.config();
     M5.begin(cfg);
 
-    if (!SPIFFS.begin(true)) {
-        Serial.println("An Error has occurred while mounting SPIFFS");
+    if (!LittleFS.begin(true)) {
+        Serial.println("An Error has occurred while mounting LittleFS");
         return;
     }
 
     const char* imagePath = "/EvilM5hub-240-135px.bmp";
 
-    if (SPIFFS.exists(imagePath)) {
+    if (LittleFS.exists(imagePath)) {
         Serial.println("Image file found, displaying image.");
 
         int16_t x_center = (M5.Display.width() - 240) / 2;
@@ -122,7 +122,7 @@ void setup() {
 
         M5.Display.setRotation(display_rotation);
         M5.Display.clear();
-        M5.Display.drawBmpFile(SPIFFS, imagePath, x_center, y_center); 
+        M5.Display.drawBmpFile(LittleFS, imagePath, x_center, y_center); 
 
         delay(5000);
 

--- a/Evil-M5Core2-1-5-1.ino
+++ b/Evil-M5Core2-1-5-1.ino
@@ -20802,7 +20802,7 @@ void scanCCTVCamerasFromFile() {
 
 
 #include <M5GFX.h>
-#include <SPIFFS.h>
+#include <LittleFS.h>
 #include <stdarg.h>
 
 // chemin du fichier liste
@@ -20837,8 +20837,8 @@ static size_t   psramBufBLen = 0;
 static const char* SD_TMP_DIR      = "/evil/tmp";
 static const char* SD_FILE_A       = "/evil/tmp/mjpeg_a.jpg";
 static const char* SD_FILE_B       = "/evil/tmp/mjpeg_b.jpg";
-static const char* SPIFFS_FILE_A   = "/a.jpg";
-static const char* SPIFFS_FILE_B   = "/b.jpg";
+static const char* LittleFS_FILE_A   = "/a.jpg";
+static const char* LittleFS_FILE_B   = "/b.jpg";
 
 static bool psramBufferingAvailable = false;
 
@@ -21681,11 +21681,11 @@ void runCCTV_MJPEGViewer() {
     psramBufferingAvailable = (psramBufA != nullptr && psramBufB != nullptr);
   }
 
-  bool spiffs_ok = false;
+  bool LittleFS_ok = false;
   bool sd_ok = true;
-  if (!sd_ok) spiffs_ok = SPIFFS.begin(true);
-  if (!sd_ok && !spiffs_ok) {
-    uiText(2, 2, "No SD/SPIFFS. Aborting.", TFT_RED);
+  if (!sd_ok) LittleFS_ok = LittleFS.begin(true);
+  if (!sd_ok && !LittleFS_ok) {
+    uiText(2, 2, "No SD/LittleFS. Aborting.", TFT_RED);
     while (1) delay(1000);
   }
   if (sd_ok && !SD.exists(SD_TMP_DIR)) SD.mkdir(SD_TMP_DIR);
@@ -21695,9 +21695,9 @@ void runCCTV_MJPEGViewer() {
     loadFallbackStreams();
   }
 
-  fs::FS* pfs = sd_ok ? (fs::FS*)&SD : (fs::FS*)&SPIFFS;
-  const char* fileA = sd_ok ? SD_FILE_A : SPIFFS_FILE_A;
-  const char* fileB = sd_ok ? SD_FILE_B : SPIFFS_FILE_B;
+  fs::FS* pfs = sd_ok ? (fs::FS*)&SD : (fs::FS*)&LittleFS;
+  const char* fileA = sd_ok ? SD_FILE_A : LittleFS_FILE_A;
+  const char* fileB = sd_ok ? SD_FILE_B : LittleFS_FILE_B;
 
   // Boucle globale : on reste ici tant que l'utilisateur ne remonte pas au menu parent
   while (!kp(KEY_ENTER)) {

--- a/Evil-NanoC6.ino
+++ b/Evil-NanoC6.ino
@@ -1,7 +1,7 @@
 #include <WiFi.h>
 #include <WebServer.h>
 #include <DNSServer.h>
-#include <SPIFFS.h>
+#include <LittleFS.h>
 #include <FS.h>
 
 //------------------------------------------------------------------
@@ -20,11 +20,11 @@ File saveFileObject;
 bool isSaveFileAuthorized = false;
 
 //------------------------------------------------------------------
-// ── OUTILS FICHIERS SPIFFS ───────────────────────────────────────
+// ── OUTILS FICHIERS LittleFS ───────────────────────────────────────
 //------------------------------------------------------------------
 void ensureFile(const char* path, const char* content = "") {
-  if (!SPIFFS.exists(path)) {
-    File f = SPIFFS.open(path, FILE_WRITE);
+  if (!LittleFS.exists(path)) {
+    File f = LittleFS.open(path, FILE_WRITE);
     if (f) {
       f.print(content);
       f.close();
@@ -33,7 +33,7 @@ void ensureFile(const char* path, const char* content = "") {
 }
 
 void initFilesystem() {
-  if (!SPIFFS.begin(true)) {
+  if (!LittleFS.begin(true)) {
     Serial.println("[FS] mount failed");
     while (true);
   }
@@ -56,7 +56,7 @@ String htmlHeader(const char* title) {
 }
 
 void saveConfig() {
-  File f = SPIFFS.open("/config.txt", FILE_WRITE);
+  File f = LittleFS.open("/config.txt", FILE_WRITE);
   if (!f) { Serial.println("! saveConfig(): open failed"); return; }
   f.printf("SSID:%s\n", clonedSSID.c_str());
   f.printf("PWD:%s\n",  captivePortalPassword.c_str());
@@ -66,7 +66,7 @@ void saveConfig() {
 }
 
 void loadConfig() {
-  File f = SPIFFS.open("/config.txt", FILE_READ);
+  File f = LittleFS.open("/config.txt", FILE_READ);
   if (!f) { Serial.println("! loadConfig(): open failed"); return; }
 
   while (f.available()) {
@@ -91,7 +91,7 @@ void loadConfig() {
 // ── PORTAL CORE ─────────────────────────────────────────────────
 //------------------------------------------------------------------
 void saveCredentials(const String & email, const String & password, const String & portalName, const String & clonedSSID) {
-  File file = SPIFFS.open("/credentials.txt", FILE_APPEND);
+  File file = LittleFS.open("/credentials.txt", FILE_APPEND);
   if (file) {
     file.println("-- Email -- \n" + email);
     file.println("-- Password -- \n" + password);
@@ -111,12 +111,12 @@ void saveCredentials(const String & email, const String & password, const String
 
 
 void servePortalFile(const String& path) {
-  if (!SPIFFS.exists(path)) {
+  if (!LittleFS.exists(path)) {
     Serial.println("File not found: " + path);
     server.send(404,"text/plain","Portal file missing");
     return;
   }
-  File f = SPIFFS.open(path, "r");
+  File f = LittleFS.open(path, "r");
   server.streamFile(f, "text/html");
   f.close();
 }
@@ -195,7 +195,7 @@ void handleSdCardBrowse() {
   String dirPath = server.arg("dir");
   if (dirPath == "") dirPath = "/";
 
-  File dir = SPIFFS.open(dirPath);
+  File dir = LittleFS.open(dirPath);
   if (!dir || !dir.isDirectory()) {
     server.send(404, "text/html", "<html><body><p>Directory not found.</p><script>setTimeout(function(){window.history.back();}, 1000);</script></body></html>");
     return;
@@ -215,8 +215,8 @@ void handleFileDownload() {
   if (!fileName.startsWith("/")) {
     fileName = "/" + fileName;
   }
-  if (SPIFFS.exists(fileName)) {
-    File file = SPIFFS.open(fileName, FILE_READ);
+  if (LittleFS.exists(fileName)) {
+    File file = LittleFS.open(fileName, FILE_READ);
     if (file) {
       String downloadName = fileName.substring(fileName.lastIndexOf('/') + 1);
       server.sendHeader("Content-Disposition", "attachment; filename=" + downloadName);
@@ -240,8 +240,8 @@ void handleFileDelete() {
   if (!fileName.startsWith("/")) {
     fileName = "/" + fileName;
   }
-  if (SPIFFS.exists(fileName)) {
-    if (SPIFFS.remove(fileName)) {
+  if (LittleFS.exists(fileName)) {
+    if (LittleFS.remove(fileName)) {
       server.send(200, "text/html", "<html><body><p>File deleted successfully</p><script>setTimeout(function(){window.location = document.referrer + '&refresh=true';}, 2000);</script></body></html>");
       Serial.println("-------------------");
       Serial.println("File deleted successfully");
@@ -267,7 +267,7 @@ void handleListDirectories() {
     return;
   }
 
-  File root = SPIFFS.open("/");
+  File root = LittleFS.open("/");
   String dirList = "";
 
   while (File file = root.openNextFile()) {
@@ -306,7 +306,7 @@ void handleFileUpload() {
 
     String fullPath = directory + filename;
 
-    fsUploadFile = SPIFFS.open(fullPath, FILE_WRITE);
+    fsUploadFile = LittleFS.open(fullPath, FILE_WRITE);
     if (!fsUploadFile) {
       Serial.println("Upload start failed: Unable to open file " + fullPath);
       server.send(500, "text/html", "File opening failed");
@@ -375,8 +375,8 @@ void handleSaveFileUpload() {
     }
 
     // Supprimer l'original s'il existe avant de sauvegarder la nouvelle version
-    if (SPIFFS.exists(saveFileName)) {
-      if (SPIFFS.remove(saveFileName)) {
+    if (LittleFS.exists(saveFileName)) {
+      if (LittleFS.remove(saveFileName)) {
         Serial.println("Original file deleted successfully: " + saveFileName);
       } else {
         Serial.println("Failed to delete original file: " + saveFileName);
@@ -386,7 +386,7 @@ void handleSaveFileUpload() {
     }
 
     // Créer un nouveau fichier pour l'écriture
-    saveFileObject = SPIFFS.open(saveFileName, FILE_WRITE);
+    saveFileObject = LittleFS.open(saveFileName, FILE_WRITE);
     if (!saveFileObject) {
       Serial.println("Failed to open file for writing: " + saveFileName);
       isSaveFileAuthorized = false;
@@ -468,8 +468,8 @@ void createCaptivePortal() {
     html += "<div class='menu'><form action='/evil-menu' method='get'>";
     html += "Password: <input type='password' name='pass'><br>";
     html += "<a href='javascript:void(0);' onclick='this.href=\"/credentials?pass=\"+document.getElementsByName(\"pass\")[0].value'>Credentials</a>";
-    html += "<a href='javascript:void(0);' onclick='this.href=\"/uploadhtmlfile?pass=\"+document.getElementsByName(\"pass\")[0].value'>Upload File On SPIFFS</a>";
-    html += "<a href='javascript:void(0);' onclick='this.href=\"/check-sd-file?pass=\"+document.getElementsByName(\"pass\")[0].value'>Check SPIFFS File</a>";
+    html += "<a href='javascript:void(0);' onclick='this.href=\"/uploadhtmlfile?pass=\"+document.getElementsByName(\"pass\")[0].value'>Upload File On LittleFS</a>";
+    html += "<a href='javascript:void(0);' onclick='this.href=\"/check-sd-file?pass=\"+document.getElementsByName(\"pass\")[0].value'>Check LittleFS File</a>";
     html += "<a href='javascript:void(0);' onclick='this.href=\"/setup-portal?pass=\"+document.getElementsByName(\"pass\")[0].value'>Setup Portal</a>";
     html += "</form></div></body></html>";
 
@@ -484,7 +484,7 @@ void createCaptivePortal() {
   server.on("/credentials", HTTP_GET, []() {
     String password = server.arg("pass");
     if (password == accessWebPassword) {
-      File file = SPIFFS.open("/credentials.txt");
+      File file = LittleFS.open("/credentials.txt");
       if (file) {
         if (file.size() == 0) {
           server.send(200, "text/html", "<html><body><p>No credentials...</p><script>setTimeout(function(){window.history.back();}, 1000);</script></body></html>");
@@ -502,7 +502,7 @@ void createCaptivePortal() {
 
 
   server.on("/check-sd-file", HTTP_GET, handleSdCardBrowse);
-  server.on("/download-SPIFFS-file", HTTP_GET, handleFileDownload);
+  server.on("/download-LittleFS-file", HTTP_GET, handleFileDownload);
   server.on("/list-directories", HTTP_GET, handleListDirectories);
 
   server.on("/uploadhtmlfile", HTTP_GET, []() {
@@ -573,7 +573,7 @@ void createCaptivePortal() {
     }
 
     String portalOptions = "";
-    File  root           = SPIFFS.open("/");
+    File  root           = LittleFS.open("/");
     int   index          = 0;
   
     while (File file = root.openNextFile()) {
@@ -701,14 +701,14 @@ void createCaptivePortal() {
     }
 
     // Check if the file exists
-    if (!SPIFFS.exists(editFileName)) {
+    if (!LittleFS.exists(editFileName)) {
       Serial.println("File not found: " + editFileName);
       server.send(404, "text/html", "<html><body><p>File not found.</p><script>setTimeout(function(){window.history.back();}, 1000);</script></body></html>");
       return;
     }
 
     // Open the file for reading
-    File editFile = SPIFFS.open(editFileName, FILE_READ);
+    File editFile = LittleFS.open(editFileName, FILE_READ);
     if (!editFile) {
       Serial.println("Failed to open file for reading: " + editFileName);
       server.send(500, "text/html", "<html><body><p>Failed to open file for reading.</p><script>setTimeout(function(){window.history.back();}, 1000);</script></body></html>");

--- a/Semi-Evil-M5Dial-v1-1-0.ino
+++ b/Semi-Evil-M5Dial-v1-1-0.ino
@@ -28,7 +28,7 @@
    Users are required to comply with all applicable laws and regulations in their jurisdiction 
    regarding network testing and ethical hacking.
 */
-#include <SPIFFS.h>
+#include <LittleFS.h>
 #include "M5Dial.h"
 #include <WiFi.h>
 #include <WebServer.h>
@@ -177,8 +177,8 @@ void setup() {
     M5Dial.Display.setTextFont(&fonts::Orbitron_Light_32);
     M5Dial.Display.setTextSize(defaultTextSize);
 
-    if (!SPIFFS.begin(true)) {
-        Serial.println("An Error has occurred while mounting SPIFFS");
+    if (!LittleFS.begin(true)) {
+        Serial.println("An Error has occurred while mounting LittleFS");
         return;
     }
 
@@ -218,7 +218,7 @@ void setup() {
 
     // Display image if exists
     const char* imagePath = "/EvilM5hub-240-135px.bmp";
-    if (SPIFFS.exists(imagePath)) {
+    if (LittleFS.exists(imagePath)) {
         Serial.println("Image file found, displaying image.");
 
         int16_t x_center1 = (M5Dial.Display.width() - 240) / 2;
@@ -226,7 +226,7 @@ void setup() {
 
         M5Dial.Display.setRotation(display_rotation);
         M5Dial.Display.clear();
-        M5Dial.Display.drawBmpFile(SPIFFS, imagePath, x_center1, y_center1);
+        M5Dial.Display.drawBmpFile(LittleFS, imagePath, x_center1, y_center1);
         delay(5000);
         M5Dial.Display.clear();
     } else {
@@ -235,7 +235,7 @@ void setup() {
 
     // Load selected SSID
     {
-        File file = SPIFFS.open("/selectedSSID.json", "r");
+        File file = LittleFS.open("/selectedSSID.json", "r");
         if (file) {
             StaticJsonDocument<256> doc;
             DeserializationError error = deserializeJson(doc, file);
@@ -252,7 +252,7 @@ void setup() {
 
     // Load SSIDs
     {
-        File file = SPIFFS.open("/SSID.json", "r");
+        File file = LittleFS.open("/SSID.json", "r");
         if (file) {
             StaticJsonDocument<1024> doc;
             DeserializationError error = deserializeJson(doc, file);
@@ -467,7 +467,7 @@ void saveSSID(const String& newSSID) {
         }
     }
 
-    File file = SPIFFS.open("/SSID.json", "w");
+    File file = LittleFS.open("/SSID.json", "w");
     if (!file) {
         if (debugMode && verboseDebug) {
             Serial.println("Failed to open SSID.json for writing");
@@ -492,7 +492,7 @@ void saveSSID(const String& newSSID) {
 }
 
 void saveSelectedSSID(const String& selectedSSID) {
-    File file = SPIFFS.open("/selectedSSID.json", "w");
+    File file = LittleFS.open("/selectedSSID.json", "w");
     if (!file) {
         if (debugMode && verboseDebug) {
             Serial.println("Failed to open selectedSSID.json for writing");
@@ -615,7 +615,7 @@ void handlePortalScreen() {
 
 void setupWebServerRoutes() {
     server.on("/", HTTP_GET, []() {
-        File file = SPIFFS.open("/index.html", "r");
+        File file = LittleFS.open("/index.html", "r");
         if (!file) {
             if (debugMode && verboseDebug) {
                 Serial.println("File not found: /index.html");
@@ -628,7 +628,7 @@ void setupWebServerRoutes() {
     });
 
     server.on("/doge.html", HTTP_GET, []() {
-        File file = SPIFFS.open("/doge.html", "r");
+        File file = LittleFS.open("/doge.html", "r");
         if (!file) {
             if (debugMode && verboseDebug) {
                 Serial.println("File not found: /doge.html");
@@ -643,7 +643,7 @@ void setupWebServerRoutes() {
     server.on("/submit", HTTP_POST, handleFormSubmit);
 
     server.on("/logs", HTTP_GET, []() {
-        File logFile = SPIFFS.open("/log.txt", "r");
+        File logFile = LittleFS.open("/log.txt", "r");
         if (logFile) {
             server.streamFile(logFile, "text/plain");
             logFile.close();
@@ -656,7 +656,7 @@ void setupWebServerRoutes() {
     });
 
     server.onNotFound([]() {
-        File file = SPIFFS.open("/index.html", "r");
+        File file = LittleFS.open("/index.html", "r");
         if (!file) {
             if (debugMode && verboseDebug) {
                 Serial.println("File not found: /index.html on NotFound");
@@ -680,7 +680,7 @@ void handleFormSubmit() {
 }
 
 void logData(String data) {
-    File logFile = SPIFFS.open("/log.txt", FILE_APPEND);
+    File logFile = LittleFS.open("/log.txt", FILE_APPEND);
     if (logFile) {
         logFile.println(data);
         logFile.close();
@@ -1153,7 +1153,7 @@ void enterExecuteScriptScreen() {
     scriptCurrentFileIndex = 0;
     scriptOldPosition = -999;
 
-    listTxtFiles(SPIFFS, "/");
+    listTxtFiles(LittleFS, "/");
     if (!scriptFileNames.empty()) {
         drawScriptMenu(scriptCurrentFileIndex);
     } else {
@@ -1246,7 +1246,7 @@ void handleExecuteScriptScreen() {
                 String msg2 = selectedFile;
                 centerText(msg2, -20);
                 String pathToFile = "/" + selectedFile;
-                readFileToSerial(SPIFFS, pathToFile.c_str());
+                readFileToSerial(LittleFS, pathToFile.c_str());
                 delay(2000);
                 drawScriptMenu(scriptCurrentFileIndex);
             }
@@ -1308,7 +1308,7 @@ void readFileToSerial(fs::FS &fs, const char *path) {
 }
 
 void executeKeystrokes(const char *filename) {
-    File file = SPIFFS.open(filename, "r");
+    File file = LittleFS.open(filename, "r");
     if (!file) {
         M5Dial.Display.drawString("Failed to Execute", M5Dial.Display.width() / 2, M5Dial.Display.height() / 2);
         if (debugMode && verboseDebug) Serial.println("Failed to open script file for BadUSB execution");

--- a/slave/NTLM-Sniffer-WebHook-ESP32.ino
+++ b/slave/NTLM-Sniffer-WebHook-ESP32.ino
@@ -1,5 +1,5 @@
 #include <WiFi.h>
-#include <SPIFFS.h>
+#include <LittleFS.h>
 #include <HTTPClient.h>
 #include <ESPAsyncWebServer.h>
 #include <ArduinoJson.h>
@@ -16,8 +16,8 @@ AsyncWebServer webServer(80);
 
 // --- Création fichiers de base si absent (config, log, index) ---
 void createFileIfMissing(const char* path, const char* content) {
-  if (!SPIFFS.exists(path)) {
-    File f = SPIFFS.open(path, FILE_WRITE);
+  if (!LittleFS.exists(path)) {
+    File f = LittleFS.open(path, FILE_WRITE);
     if (f) {
       f.print(content);
       f.close();
@@ -25,9 +25,9 @@ void createFileIfMissing(const char* path, const char* content) {
   }
 }
 
-// --- Initialisation SPIFFS et fichiers de base ---
-void initSPIFFS() {
-  if (!SPIFFS.begin(true)) return;
+// --- Initialisation LittleFS et fichiers de base ---
+void initLittleFS() {
+  if (!LittleFS.begin(true)) return;
   createFileIfMissing(configPath, "{\"ssid\":\"\",\"password\":\"\",\"webhook\":\"\"}");
   createFileIfMissing(logPath, "");
   createFileIfMissing(indexPath,
@@ -68,7 +68,7 @@ void initSPIFFS() {
 
 // --- Charger la config utilisateur ---
 bool loadConfig() {
-  File file = SPIFFS.open(configPath, "r");
+  File file = LittleFS.open(configPath, "r");
   if (!file || file.size() == 0) return false;
   JsonDocument doc;
   DeserializationError err = deserializeJson(doc, file);
@@ -82,10 +82,10 @@ bool loadConfig() {
 
 // --- Serveur Web UI pour config ---
 void setupWebUI() {
-  webServer.serveStatic("/", SPIFFS, "/").setDefaultFile("index.html");
+  webServer.serveStatic("/", LittleFS, "/").setDefaultFile("index.html");
 
   webServer.on("/config", HTTP_GET, [](AsyncWebServerRequest * request) {
-    File file = SPIFFS.open(configPath, "r");
+    File file = LittleFS.open(configPath, "r");
     if (!file) {
       request->send(500, "application/json", "{\"error\":\"Unable to open config file\"}");
       return;
@@ -97,7 +97,7 @@ void setupWebUI() {
   });
   webServer.on("/config", HTTP_POST, [](AsyncWebServerRequest * request) {}, NULL,
   [](AsyncWebServerRequest * request, uint8_t *data, size_t len, size_t, size_t) {
-    File file = SPIFFS.open(configPath, "w");
+    File file = LittleFS.open(configPath, "w");
     if (!file) {
       request->send(500, "text/plain", "Error: Cannot write config file");
       return;
@@ -107,7 +107,7 @@ void setupWebUI() {
   });
 
   webServer.on("/log", HTTP_GET, [](AsyncWebServerRequest * request) {
-    File file = SPIFFS.open(logPath, "r");
+    File file = LittleFS.open(logPath, "r");
     if (!file) {
       request->send(500, "text/plain", "Cannot open log file");
       return;
@@ -125,7 +125,7 @@ void setupWebUI() {
   });
 
   webServer.on("/reset", HTTP_POST, [](AsyncWebServerRequest * request) {
-    SPIFFS.remove(configPath);
+    LittleFS.remove(configPath);
     request->send(200, "text/plain", "Configuration reset...");
     delay(500);
     ESP.restart();
@@ -171,13 +171,13 @@ void setup() {
   pinMode(CONFIG_PIN, INPUT_PULLDOWN);
 
   if (digitalRead(CONFIG_PIN) == HIGH) {
-    initSPIFFS();
+    initLittleFS();
     Serial.print("Setup Config WebUI.");
     setupWebUI();
     return;
   }
   
-  initSPIFFS();
+  initLittleFS();
   
   if (!loadConfig()) {
     setupWebUI();
@@ -449,7 +449,7 @@ void extractAndPrintHash(uint8_t* pkt, uint32_t smbLength, uint8_t* ntlm) {
   Serial.println("------------------------------------");
 
   // 8. Save sur SD
-  File file = SPIFFS.open("/ntlm_hashes.txt", FILE_APPEND);
+  File file = LittleFS.open("/ntlm_hashes.txt", FILE_APPEND);
   if (file) {
     file.println(finalHash);
     file.close();

--- a/slave/NTLM-Sniffer-WebHook-NanoC6.ino
+++ b/slave/NTLM-Sniffer-WebHook-NanoC6.ino
@@ -1,6 +1,6 @@
 #include <M5NanoC6.h>
 #include <WiFi.h>
-#include <SPIFFS.h>
+#include <LittleFS.h>
 #include <HTTPClient.h>
 #include <ESPAsyncWebServer.h>
 #include <ArduinoJson.h>
@@ -22,8 +22,8 @@ AsyncWebServer webServer(80);
 
 // --- Création fichiers de base si absent (config, log, index) ---
 void createFileIfMissing(const char* path, const char* content) {
-  if (!SPIFFS.exists(path)) {
-    File f = SPIFFS.open(path, FILE_WRITE);
+  if (!LittleFS.exists(path)) {
+    File f = LittleFS.open(path, FILE_WRITE);
     if (f) {
       f.print(content);
       f.close();
@@ -31,9 +31,9 @@ void createFileIfMissing(const char* path, const char* content) {
   }
 }
 
-// --- Initialisation SPIFFS et fichiers de base ---
-void initSPIFFS() {
-  if (!SPIFFS.begin(true)) return;
+// --- Initialisation LittleFS et fichiers de base ---
+void initLittleFS() {
+  if (!LittleFS.begin(true)) return;
   createFileIfMissing(configPath, "{\"ssid\":\"\",\"password\":\"\",\"webhook\":\"\"}");
   createFileIfMissing(logPath, "");
   createFileIfMissing(indexPath,
@@ -74,7 +74,7 @@ void initSPIFFS() {
 
 // --- Charger la config utilisateur ---
 bool loadConfig() {
-  File file = SPIFFS.open(configPath, "r");
+  File file = LittleFS.open(configPath, "r");
   if (!file || file.size() == 0) return false;
   JsonDocument doc;
   DeserializationError err = deserializeJson(doc, file);
@@ -88,10 +88,10 @@ bool loadConfig() {
 
 // --- Serveur Web UI pour config ---
 void setupWebUI() {
-  webServer.serveStatic("/", SPIFFS, "/").setDefaultFile("index.html");
+  webServer.serveStatic("/", LittleFS, "/").setDefaultFile("index.html");
 
   webServer.on("/config", HTTP_GET, [](AsyncWebServerRequest * request) {
-    File file = SPIFFS.open(configPath, "r");
+    File file = LittleFS.open(configPath, "r");
     if (!file) {
       request->send(500, "application/json", "{\"error\":\"Unable to open config file\"}");
       return;
@@ -103,7 +103,7 @@ void setupWebUI() {
   });
   webServer.on("/config", HTTP_POST, [](AsyncWebServerRequest * request) {}, NULL,
   [](AsyncWebServerRequest * request, uint8_t *data, size_t len, size_t, size_t) {
-    File file = SPIFFS.open(configPath, "w");
+    File file = LittleFS.open(configPath, "w");
     if (!file) {
       request->send(500, "text/plain", "Error: Cannot write config file");
       return;
@@ -113,7 +113,7 @@ void setupWebUI() {
   });
 
   webServer.on("/log", HTTP_GET, [](AsyncWebServerRequest * request) {
-    File file = SPIFFS.open(logPath, "r");
+    File file = LittleFS.open(logPath, "r");
     if (!file) {
       request->send(500, "text/plain", "Cannot open log file");
       return;
@@ -131,7 +131,7 @@ void setupWebUI() {
   });
 
   webServer.on("/reset", HTTP_POST, [](AsyncWebServerRequest * request) {
-    SPIFFS.remove(configPath);
+    LittleFS.remove(configPath);
     request->send(200, "text/plain", "Configuration reset...");
     delay(500);
     ESP.restart();
@@ -201,13 +201,13 @@ void setup() {
 
   // Bouton A maintenu : config web direct
   if (NanoC6.BtnA.isPressed()) {
-    initSPIFFS();
+    initLittleFS();
     strip.setPixelColor(0, strip.Color(0, 0, 255)); strip.show();
     setupWebUI();
     return;
   }
 
-  initSPIFFS();
+  initLittleFS();
   strip.setPixelColor(0, strip.Color(0, 0, 0)); strip.show();
 
   if (!loadConfig()) {
@@ -486,7 +486,7 @@ void extractAndPrintHash(uint8_t* pkt, uint32_t smbLength, uint8_t* ntlm) {
   Serial.println("------------------------------------");
 
   // 8. Save sur SD
-  File file = SPIFFS.open("/ntlm_hashes.txt", FILE_APPEND);
+  File file = LittleFS.open("/ntlm_hashes.txt", FILE_APPEND);
   if (file) {
     file.println(finalHash);
     file.close();

--- a/slave/README.md
+++ b/slave/README.md
@@ -38,7 +38,7 @@ Designed to be used with Handshake Master. EAPOL sniffer that remains on a stati
 Designed to be used with EvilChatMesh. Relay for the EvilChatMesh network, it can be used to extend the range of the network. Version AtomS3 print information on screen. 
 
 ### `slave_portal.ino`
-Standalone version of the Ecil-M5Project portal fonctionnality, usinf SPIFFS to store files and WebUi to be configured and upload files.
+Standalone version of the Ecil-M5Project portal fonctionnality, using LittleFS to store files and WebUi to be configured and upload files.
 
 ## Tested on:
 - **AtomS3**: [Buy here](https://s.click.aliexpress.com/e/_DnDXSKJ)

--- a/slave/slave_portal.ino
+++ b/slave/slave_portal.ino
@@ -1,7 +1,7 @@
 #include <WiFi.h>
 #include <WebServer.h>
 #include <DNSServer.h>
-#include <SPIFFS.h>
+#include <LittleFS.h>
 #include <FS.h>
 
 //------------------------------------------------------------------
@@ -20,11 +20,11 @@ File saveFileObject;
 bool isSaveFileAuthorized = false;
 
 //------------------------------------------------------------------
-// ── OUTILS FICHIERS SPIFFS ───────────────────────────────────────
+// ── OUTILS FICHIERS LittleFS ───────────────────────────────────────
 //------------------------------------------------------------------
 void ensureFile(const char* path, const char* content = "") {
-  if (!SPIFFS.exists(path)) {
-    File f = SPIFFS.open(path, FILE_WRITE);
+  if (!LittleFS.exists(path)) {
+    File f = LittleFS.open(path, FILE_WRITE);
     if (f) {
       f.print(content);
       f.close();
@@ -33,7 +33,7 @@ void ensureFile(const char* path, const char* content = "") {
 }
 
 void initFilesystem() {
-  if (!SPIFFS.begin(true)) {
+  if (!LittleFS.begin(true)) {
     Serial.println("[FS] mount failed");
     while (true);
   }
@@ -56,7 +56,7 @@ String htmlHeader(const char* title) {
 }
 
 void saveConfig() {
-  File f = SPIFFS.open("/config.txt", FILE_WRITE);
+  File f = LittleFS.open("/config.txt", FILE_WRITE);
   if (!f) { Serial.println("! saveConfig(): open failed"); return; }
   f.printf("SSID:%s\n", clonedSSID.c_str());
   f.printf("PWD:%s\n",  captivePortalPassword.c_str());
@@ -66,7 +66,7 @@ void saveConfig() {
 }
 
 void loadConfig() {
-  File f = SPIFFS.open("/config.txt", FILE_READ);
+  File f = LittleFS.open("/config.txt", FILE_READ);
   if (!f) { Serial.println("! loadConfig(): open failed"); return; }
 
   while (f.available()) {
@@ -91,7 +91,7 @@ void loadConfig() {
 // ── PORTAL CORE ─────────────────────────────────────────────────
 //------------------------------------------------------------------
 void saveCredentials(const String & email, const String & password, const String & portalName, const String & clonedSSID) {
-  File file = SPIFFS.open("/credentials.txt", FILE_APPEND);
+  File file = LittleFS.open("/credentials.txt", FILE_APPEND);
   if (file) {
     file.println("-- Email -- \n" + email);
     file.println("-- Password -- \n" + password);
@@ -111,12 +111,12 @@ void saveCredentials(const String & email, const String & password, const String
 
 
 void servePortalFile(const String& path) {
-  if (!SPIFFS.exists(path)) {
+  if (!LittleFS.exists(path)) {
     Serial.println("File not found: " + path);
     server.send(404,"text/plain","Portal file missing");
     return;
   }
-  File f = SPIFFS.open(path, "r");
+  File f = LittleFS.open(path, "r");
   server.streamFile(f, "text/html");
   f.close();
 }
@@ -195,7 +195,7 @@ void handleSdCardBrowse() {
   String dirPath = server.arg("dir");
   if (dirPath == "") dirPath = "/";
 
-  File dir = SPIFFS.open(dirPath);
+  File dir = LittleFS.open(dirPath);
   if (!dir || !dir.isDirectory()) {
     server.send(404, "text/html", "<html><body><p>Directory not found.</p><script>setTimeout(function(){window.history.back();}, 1000);</script></body></html>");
     return;
@@ -215,8 +215,8 @@ void handleFileDownload() {
   if (!fileName.startsWith("/")) {
     fileName = "/" + fileName;
   }
-  if (SPIFFS.exists(fileName)) {
-    File file = SPIFFS.open(fileName, FILE_READ);
+  if (LittleFS.exists(fileName)) {
+    File file = LittleFS.open(fileName, FILE_READ);
     if (file) {
       String downloadName = fileName.substring(fileName.lastIndexOf('/') + 1);
       server.sendHeader("Content-Disposition", "attachment; filename=" + downloadName);
@@ -240,8 +240,8 @@ void handleFileDelete() {
   if (!fileName.startsWith("/")) {
     fileName = "/" + fileName;
   }
-  if (SPIFFS.exists(fileName)) {
-    if (SPIFFS.remove(fileName)) {
+  if (LittleFS.exists(fileName)) {
+    if (LittleFS.remove(fileName)) {
       server.send(200, "text/html", "<html><body><p>File deleted successfully</p><script>setTimeout(function(){window.location = document.referrer + '&refresh=true';}, 2000);</script></body></html>");
       Serial.println("-------------------");
       Serial.println("File deleted successfully");
@@ -267,7 +267,7 @@ void handleListDirectories() {
     return;
   }
 
-  File root = SPIFFS.open("/");
+  File root = LittleFS.open("/");
   String dirList = "";
 
   while (File file = root.openNextFile()) {
@@ -306,7 +306,7 @@ void handleFileUpload() {
 
     String fullPath = directory + filename;
 
-    fsUploadFile = SPIFFS.open(fullPath, FILE_WRITE);
+    fsUploadFile = LittleFS.open(fullPath, FILE_WRITE);
     if (!fsUploadFile) {
       Serial.println("Upload start failed: Unable to open file " + fullPath);
       server.send(500, "text/html", "File opening failed");
@@ -375,8 +375,8 @@ void handleSaveFileUpload() {
     }
 
     // Supprimer l'original s'il existe avant de sauvegarder la nouvelle version
-    if (SPIFFS.exists(saveFileName)) {
-      if (SPIFFS.remove(saveFileName)) {
+    if (LittleFS.exists(saveFileName)) {
+      if (LittleFS.remove(saveFileName)) {
         Serial.println("Original file deleted successfully: " + saveFileName);
       } else {
         Serial.println("Failed to delete original file: " + saveFileName);
@@ -386,7 +386,7 @@ void handleSaveFileUpload() {
     }
 
     // Créer un nouveau fichier pour l'écriture
-    saveFileObject = SPIFFS.open(saveFileName, FILE_WRITE);
+    saveFileObject = LittleFS.open(saveFileName, FILE_WRITE);
     if (!saveFileObject) {
       Serial.println("Failed to open file for writing: " + saveFileName);
       isSaveFileAuthorized = false;
@@ -468,8 +468,8 @@ void createCaptivePortal() {
     html += "<div class='menu'><form action='/evil-menu' method='get'>";
     html += "Password: <input type='password' name='pass'><br>";
     html += "<a href='javascript:void(0);' onclick='this.href=\"/credentials?pass=\"+document.getElementsByName(\"pass\")[0].value'>Credentials</a>";
-    html += "<a href='javascript:void(0);' onclick='this.href=\"/uploadhtmlfile?pass=\"+document.getElementsByName(\"pass\")[0].value'>Upload File On SPIFFS</a>";
-    html += "<a href='javascript:void(0);' onclick='this.href=\"/check-sd-file?pass=\"+document.getElementsByName(\"pass\")[0].value'>Check SPIFFS File</a>";
+    html += "<a href='javascript:void(0);' onclick='this.href=\"/uploadhtmlfile?pass=\"+document.getElementsByName(\"pass\")[0].value'>Upload File On LittleFS</a>";
+    html += "<a href='javascript:void(0);' onclick='this.href=\"/check-sd-file?pass=\"+document.getElementsByName(\"pass\")[0].value'>Check LittleFS File</a>";
     html += "<a href='javascript:void(0);' onclick='this.href=\"/setup-portal?pass=\"+document.getElementsByName(\"pass\")[0].value'>Setup Portal</a>";
     html += "</form></div></body></html>";
 
@@ -484,7 +484,7 @@ void createCaptivePortal() {
   server.on("/credentials", HTTP_GET, []() {
     String password = server.arg("pass");
     if (password == accessWebPassword) {
-      File file = SPIFFS.open("/credentials.txt");
+      File file = LittleFS.open("/credentials.txt");
       if (file) {
         if (file.size() == 0) {
           server.send(200, "text/html", "<html><body><p>No credentials...</p><script>setTimeout(function(){window.history.back();}, 1000);</script></body></html>");
@@ -502,7 +502,7 @@ void createCaptivePortal() {
 
 
   server.on("/check-sd-file", HTTP_GET, handleSdCardBrowse);
-  server.on("/download-SPIFFS-file", HTTP_GET, handleFileDownload);
+  server.on("/download-LittleFS-file", HTTP_GET, handleFileDownload);
   server.on("/list-directories", HTTP_GET, handleListDirectories);
 
   server.on("/uploadhtmlfile", HTTP_GET, []() {
@@ -573,7 +573,7 @@ void createCaptivePortal() {
     }
 
     String portalOptions = "";
-    File  root           = SPIFFS.open("/");
+    File  root           = LittleFS.open("/");
     int   index          = 0;
   
     while (File file = root.openNextFile()) {
@@ -701,14 +701,14 @@ void createCaptivePortal() {
     }
 
     // Check if the file exists
-    if (!SPIFFS.exists(editFileName)) {
+    if (!LittleFS.exists(editFileName)) {
       Serial.println("File not found: " + editFileName);
       server.send(404, "text/html", "<html><body><p>File not found.</p><script>setTimeout(function(){window.history.back();}, 1000);</script></body></html>");
       return;
     }
 
     // Open the file for reading
-    File editFile = SPIFFS.open(editFileName, FILE_READ);
+    File editFile = LittleFS.open(editFileName, FILE_READ);
     if (!editFile) {
       Serial.println("Failed to open file for reading: " + editFileName);
       server.send(500, "text/html", "<html><body><p>Failed to open file for reading.</p><script>setTimeout(function(){window.history.back();}, 1000);</script></body></html>");


### PR DESCRIPTION
## 🚀 Why Switch from SPIFFS to LittleFS?
SPIFFS has served the ESP32 community well, but it has been officially deprecated in favor of LittleFS. Here is why this migration benefits Evil-M5Project:

- **Power-Loss Resilience (Copy-on-Write):** LittleFS uses atomic operations and a copy-on-write dynamic. If the device loses power or resets while writing a file, the filesystem rolls back to the last valid state instead of leaving a corrupted file behind.

- **Wear Leveling:** LittleFS actively distributes write/erase cycles evenly across the flash memory sectors, significantly extending the lifespan of the onboard SPI flash chip.

- **Real Directory Support:** Unlike SPIFFS, which simulates directories using flat filenames containing slashes (e.g., /folder/file.txt), LittleFS natively supports true directories and subdirectories, improving file lookup performance and structure.

- **Lower RAM Footprint:** SPIFFS indexes the entire filesystem in RAM on mount, which grows with flash size. LittleFS utilizes dynamic indexing, keeping RAM usage much lower and predictable.

- **Faster Operations:** Directory listings, file opens, and seeks are notably faster in LittleFS compared to SPIFFS on larger partition sizes.

And the most important thing.. While using Launcher, it won't lose data when moving back and forth from Meshtastic or Bruce, so nobody loses data. 😉 